### PR TITLE
bifurcate io.Reader and io.ReadSeeker functionality

### DIFF
--- a/header.go
+++ b/header.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
-	"time"
 )
 
 // ArchiveEntry represents an libarchive archive_entry
@@ -68,9 +67,6 @@ func (e *entryInfo) Mode() os.FileMode {
 		mode |= os.ModeNamedPipe
 	}
 	return mode
-}
-func (e *entryInfo) ModTime() time.Time {
-	return time.Unix(int64(e.stat.st_mtim.tv_sec), int64(e.stat.st_mtim.tv_nsec))
 }
 func (e *entryInfo) IsDir() bool {
 	return e.stat.st_mode&syscall.S_IFDIR != 0

--- a/header_darwin.go
+++ b/header_darwin.go
@@ -1,0 +1,14 @@
+package archive
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"time"
+)
+
+func (e *entryInfo) ModTime() time.Time {
+	return time.Unix(int64(e.stat.st_mtimespec.tv_sec), int64(e.stat.st_mtimespec.tv_nsec))
+}

--- a/header_linux.go
+++ b/header_linux.go
@@ -1,0 +1,14 @@
+package archive
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"time"
+)
+
+func (e *entryInfo) ModTime() time.Time {
+	return time.Unix(int64(e.stat.st_mtim.tv_sec), int64(e.stat.st_mtim.tv_nsec))
+}


### PR DESCRIPTION
This is the promised patchset to bifurcate `io.Reader` and `io.ReadSeeker` functionality. 