### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/readseeker.go
+++ b/readseeker.go
@@ -22,7 +22,7 @@ type ReedSeeker struct {
 	index   int64         // current reading index
 }
 
-// NewReader returns new Archive by calling archive_read_open
+// NewReadSeeker returns new Archive by calling archive_read_open
 func NewReadSeeker(reader io.ReadSeeker) (r *ReedSeeker, err error) {
 	r = new(ReedSeeker)
 	r.buffer = make([]byte, 1024)


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?